### PR TITLE
Update to clap 3.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/dtolnay/sha1dir"
 readme = "README.md"
 
 [dependencies]
-clap = { version = "3.0", default-features = false, features = ["derive", "std", "suggestions"] }
+clap = { version = "3.1", default-features = false, features = ["derive", "std", "suggestions"] }
 memmap = "0.7"
 num_cpus = "1.0"
 parking_lot = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,5 +218,5 @@ fn begin(path: &Path, metadata: &Metadata, kind: u8) -> Sha1 {
 
 #[test]
 fn test_cli() {
-    <Opt as clap::IntoApp>::into_app().debug_assert();
+    <Opt as clap::CommandFactory>::command().debug_assert();
 }


### PR DESCRIPTION
There are several deprecations in this release:
https://github.com/clap-rs/clap/releases/tag/v3.1.0