### PR TITLE
Update to clap 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.54.0]
+        rust: [nightly, beta, stable, 1.56.0]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/dtolnay/sha1dir"
 readme = "README.md"
 
 [dependencies]
-clap = { version = "3.1", default-features = false, features = ["derive", "std", "suggestions"] }
+clap = { version = "3.2", default-features = false, features = ["derive", "std", "suggestions"] }
 memmap = "0.7"
 num_cpus = "1.0"
 parking_lot = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,11 @@ fn die<P: AsRef<Path>, E: Display>(path: P, error: E) -> ! {
 #[clap(about = "Compute checksum of directory.", version, author)]
 struct Opt {
     /// Number of hashes to compute in parallel
-    #[clap(short)]
+    #[clap(short, action)]
     jobs: Option<usize>,
 
     /// Directories to hash
-    #[clap(value_name = "DIR", parse(from_os_str))]
+    #[clap(value_name = "DIR", action)]
     dirs: Vec<PathBuf>,
 }
 


### PR DESCRIPTION
Context: https://epage.github.io/blog/2022/06/clap-32-last-call-before-40/