### PR TITLE
Update argument parser to clap 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/sha1dir"
 
 [dependencies]
-clap = { version = "3.2.5", default-features = false, features = ["deprecated", "derive", "std", "suggestions"] }
+clap = { version = "4", features = ["deprecated", "derive"] }
 memmap = "0.7"
 num_cpus = "1.0"
 parking_lot = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,14 +46,14 @@ fn die<P: AsRef<Path>, E: Display>(path: P, error: E) -> ! {
 }
 
 #[derive(Debug, Parser)]
-#[clap(about = "Compute checksum of directory.", version, author)]
+#[command(about = "Compute checksum of directory.", version, author)]
 struct Opt {
     /// Number of hashes to compute in parallel
-    #[clap(short, action)]
+    #[arg(short)]
     jobs: Option<usize>,
 
     /// Directories to hash
-    #[clap(value_name = "DIR", action)]
+    #[arg(value_name = "DIR")]
     dirs: Vec<PathBuf>,
 }
 


### PR DESCRIPTION
Release announcement: https://epage.github.io/blog/2022/09/clap4/