### PR TITLE
Add --exclude-rootdir-metadata option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ entry. The hash for each directory entry is the hash of the following body:
 
 The resulting checksum is 160 bits wide like SHA-1.
 
+The mode for the topmost directory may be excluded from the checksum using the
+`--exclude-rootdir-metadata` command line option.
+
 <br>
 
 #### License


### PR DESCRIPTION
This adds a new CLI option `--exclude-rootdir-metadata`, which may be used to exclude the mode for the topmost directory from the checksum.

It's worth saying that this is the second and final PR that I need to make `sha1dir` useful for my scenario, which I will briefly outline.  I do not anticipate any more changes being required!

My scenario is re-homing around 3000 filesystems comprising around 200 million files totaling 600TB data from 6 ancient ZFS fileservers that are to be decommissioned to an all-singing-all-dancing new GPFS storage platform.  The migration uses many rsyncs in parallel, but with the various network outages and storage glitches that occur during the course of the few months that this is taking, a separate verification stage is necessary to provide assurance of migration integrity.  For this, `sha1dir` has been so very good, being about 5 times faster than the naive `find . -type f -print0 | LC_ALL=C sort -z | xargs -0 cat | sha1sum`.  Thank you!

The toplevel directories on the new storage platform have different permissions than on the legacy fileservers, which is why this rather odd exclusion is useful.  Hopefully to others too!