### PR TITLE
Optionally write individual checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ entry. The hash for each directory entry is the hash of the following body:
 
 The resulting checksum is 160 bits wide like SHA-1.
 
+If the checksum is unexpectedly different, the `--write-checksums` option may
+be used to dump individual checksums into the specified file, to facilitate
+entry-by-entry comparison (after sorting).
+
 <br>
 
 #### License

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ struct Opt {
     dirs: Vec<PathBuf>,
 
     /// Whether and where to write individual checksums
-    #[arg(long)]
+    #[arg(long, value_name = "FILE")]
     write_checksums: Option<PathBuf>,
 
     /// Whether to ignore unknown filetypes (otherwise fatal)

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
 use std::process;
+use std::sync::Arc;
 use std::sync::Once;
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
@@ -63,6 +64,10 @@ struct Opt {
     #[arg(value_name = "DIR")]
     dirs: Vec<PathBuf>,
 
+    /// Whether and where to write individual checksums
+    #[arg(long)]
+    write_checksums: Option<PathBuf>,
+
     /// Whether to ignore unknown filetypes (otherwise fatal)
     #[arg(long)]
     ignore_unknown_filetypes: bool,
@@ -73,9 +78,13 @@ fn main() {
 
     configure_thread_pool(&opt);
 
+    let write_checksums = opt
+        .write_checksums
+        .map(|path| Arc::new(Mutex::new(File::create(path).unwrap())));
+
     if opt.dirs.is_empty() {
         let path = Path::new(".");
-        let checksum = checksum_current_dir(path, opt.ignore_unknown_filetypes);
+        let checksum = checksum_current_dir(path, opt.ignore_unknown_filetypes, &write_checksums);
         let _ = writeln!(io::stdout(), "{}", checksum);
         return;
     }
@@ -86,7 +95,7 @@ fn main() {
         if let Err(error) = env::set_current_dir(canonical) {
             die(label, error);
         }
-        let checksum = checksum_current_dir(&label, opt.ignore_unknown_filetypes);
+        let checksum = checksum_current_dir(&label, opt.ignore_unknown_filetypes, &write_checksums);
         let _ = writeln!(io::stdout(), "{}  {}", checksum, label.display());
     }
 }
@@ -141,7 +150,11 @@ impl Checksum {
     }
 }
 
-fn checksum_current_dir(label: &Path, ignore_unknown_filetypes: bool) -> Checksum {
+fn checksum_current_dir(
+    label: &Path,
+    ignore_unknown_filetypes: bool,
+    write_checksums: &Option<Arc<Mutex<File>>>,
+) -> Checksum {
     let checksum = Checksum::new();
     rayon::scope(|scope| {
         if let Err(error) = (|| -> Result<()> {
@@ -156,6 +169,7 @@ fn checksum_current_dir(label: &Path, ignore_unknown_filetypes: bool) -> Checksu
                             checksum,
                             Path::new(&child.file_name()),
                             ignore_unknown_filetypes,
+                            write_checksums,
                         );
                     }
                 });
@@ -174,6 +188,7 @@ fn entry<'scope>(
     checksum: &'scope Checksum,
     path: &Path,
     ignore_unknown_filetypes: bool,
+    write_checksums: &'scope Option<Arc<Mutex<File>>>,
 ) {
     let metadata = match path.symlink_metadata() {
         Ok(metadata) => metadata,
@@ -182,9 +197,9 @@ fn entry<'scope>(
 
     let file_type = metadata.file_type();
     let result = if file_type.is_file() {
-        file(checksum, path, metadata)
+        file(checksum, path, metadata, write_checksums)
     } else if file_type.is_symlink() {
-        symlink(checksum, path, metadata)
+        symlink(checksum, path, metadata, write_checksums)
     } else if file_type.is_dir() {
         dir(
             scope,
@@ -193,9 +208,10 @@ fn entry<'scope>(
             path,
             ignore_unknown_filetypes,
             metadata,
+            write_checksums,
         )
     } else if file_type.is_socket() {
-        socket(checksum, path, metadata)
+        socket(checksum, path, metadata, write_checksums)
     } else if ignore_unknown_filetypes {
         Ok(())
     } else {
@@ -207,7 +223,12 @@ fn entry<'scope>(
     }
 }
 
-fn file(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
+fn file(
+    checksum: &Checksum,
+    path: &Path,
+    metadata: Metadata,
+    write_checksums: &Option<Arc<Mutex<File>>>,
+) -> Result<()> {
     let mut sha = begin(path, &metadata, b'f');
 
     // Enforced by memmap: "memory map must have a non-zero length"
@@ -217,14 +238,28 @@ fn file(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
         sha.update(&mmap);
     }
 
+    if let Some(w) = write_checksums {
+        write_sha(w, path, &sha)?;
+    }
+
     checksum.put(sha);
 
     Ok(())
 }
 
-fn symlink(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
+fn symlink(
+    checksum: &Checksum,
+    path: &Path,
+    metadata: Metadata,
+    write_checksums: &Option<Arc<Mutex<File>>>,
+) -> Result<()> {
     let mut sha = begin(path, &metadata, b'l');
     sha.update(path.read_link()?.as_os_str().as_bytes());
+
+    if let Some(w) = write_checksums {
+        write_sha(w, path, &sha)?;
+    }
+
     checksum.put(sha);
 
     Ok(())
@@ -237,20 +272,45 @@ fn dir<'scope>(
     path: &Path,
     ignore_unknown_filetypes: bool,
     metadata: Metadata,
+    write_checksums: &'scope Option<Arc<Mutex<File>>>,
 ) -> Result<()> {
     let sha = begin(path, &metadata, b'd');
+
+    if let Some(w) = write_checksums {
+        write_sha(w, path, &sha)?;
+    }
+
     checksum.put(sha);
 
     for child in path.read_dir()? {
         let child = child?.path();
-        scope.spawn(move |scope| entry(scope, base, checksum, &child, ignore_unknown_filetypes));
+        scope.spawn(move |scope| {
+            entry(
+                scope,
+                base,
+                checksum,
+                &child,
+                ignore_unknown_filetypes,
+                write_checksums,
+            )
+        });
     }
 
     Ok(())
 }
 
-fn socket(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
+fn socket(
+    checksum: &Checksum,
+    path: &Path,
+    metadata: Metadata,
+    write_checksums: &Option<Arc<Mutex<File>>>,
+) -> Result<()> {
     let sha = begin(path, &metadata, b's');
+
+    if let Some(w) = write_checksums {
+        write_sha(w, path, &sha)?;
+    }
+
     checksum.put(sha);
 
     Ok(())
@@ -264,6 +324,12 @@ fn begin(path: &Path, metadata: &Metadata, kind: u8) -> Sha1 {
     sha.update(path_bytes);
     sha.update(metadata.mode().to_le_bytes());
     sha
+}
+
+fn write_sha(f: &Arc<Mutex<File>>, path: &Path, sha: &Sha1) -> Result<()> {
+    let sha = sha.clone();
+    writeln!(f.lock(), "{} {:x}", path.to_string_lossy(), sha.finalize())?;
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
In a large directory tree which fails its checksum, it can be onerous to work out why that is.

In my usage, I have large directory trees where a user may have set bad permissions (user missing `x` on a directory, for instance).  When such is transferred, `rsync` helpfully fixes the bad permission (so that the children may be copied).  But the checksum comparison then fails, and it is not straightforward to determine why that is.

This change introduces a `--write-checksums` option, which may be used to dump individual checksums to a file (in undefined order).  Once sorted, `diff` is useful on such a file.

Example usage:
```
$ find junk | sort
junk
junk/a
junk/b
junk/c
junk/c/d

$ sha1dir --write-checksums ~/junk.checksums junk
8699a7c49c0a785b039df6a1a9a0c255979f1262  junk

$ cat ~/junk.checksums
a 3c6f8cbff8aae7eb2130d9f9caf8b96984180004
c 2f1837838211cce2c9b29031688ece53ebb8abf8
b 66d0ab2e00ae6742900f2b80f9c59b2829e1d3c2
c/d f33eb7d6e61f34107b1094e9f2132e47d1de6a5c
```