### PR TITLE
Remove option_if_let_else clippy suppression

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@
     clippy::let_underscore_untyped,
     clippy::needless_collect,
     clippy::needless_pass_by_value,
-    clippy::option_if_let_else,
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps,
     clippy::unseparated_literal_suffix


### PR DESCRIPTION
This lint got downgraded from `pedantic` to `nursery` by https://github.com/rust-lang/rust-clippy/pull/7568 so we no longer run it.