### PR TITLE
Turning sha1dir into a Library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/sha1dir"
 
+[lib]
+name = "sha1dir"
+path = "src/lib.rs"
+
 [dependencies]
 clap = { version = "4", features = ["deprecated", "derive"] }
 memmap = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,223 @@
+//! [![github]](https://github.com/dtolnay/sha1dir)&ensp;[![crates-io]](https://crates.io/crates/sha1dir)&ensp;[![docs-rs]](https://docs.rs/sha1dir)
+//!
+//! [github]: https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github
+//! [crates-io]: https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust
+//! [docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::let_underscore_untyped,
+    clippy::needless_collect,
+    clippy::needless_pass_by_value,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_wraps,
+    clippy::unseparated_literal_suffix
+)]
+
+use memmap::Mmap;
+use parking_lot::Mutex;
+use rayon::{Scope, ThreadPoolBuilder};
+use sha1::{Digest, Sha1};
+use std::env;
+use std::error::Error;
+use std::fmt::{self, Display};
+use std::fs::{self, File, Metadata};
+use std::io::{self, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::sync::Once;
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+pub fn die<P: AsRef<Path>, E: Display>(path: P, error: E) -> ! {
+    static DIE: Once = Once::new();
+
+    DIE.call_once(|| {
+        let path = path.as_ref().display();
+        let _ = writeln!(
+            io::stderr(),
+            "{}: {}: {}",
+            env!("CARGO_BIN_NAME"),
+            path,
+            error,
+        );
+        process::exit(1);
+    });
+
+    unreachable!()
+}
+
+pub fn configure_thread_pool(threads: usize) {
+    let result = ThreadPoolBuilder::new().num_threads(threads).build_global();
+
+    // This is the only time the thread pool is initialized.
+    result.unwrap();
+}
+
+pub fn canonicalize<P: AsRef<Path>>(path: P) -> PathBuf {
+    match fs::canonicalize(&path) {
+        Ok(canonical) => canonical,
+        Err(error) => die(path, error),
+    }
+}
+
+pub struct Checksum {
+    bytes: Mutex<[u8; 20]>,
+}
+
+impl Checksum {
+    fn new() -> Self {
+        Checksum {
+            bytes: Mutex::new([0u8; 20]),
+        }
+    }
+}
+
+impl Display for Checksum {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for i in self.bytes.lock().as_ref() {
+            write!(f, "{:02x}", i)?;
+        }
+        Ok(())
+    }
+}
+
+impl Checksum {
+    fn put(&self, rhs: Sha1) {
+        for (lhs, rhs) in self.bytes.lock().iter_mut().zip(rhs.finalize()) {
+            *lhs ^= rhs;
+        }
+    }
+}
+
+pub fn checksum_current_dir(label: &Path, ignore_unknown_filetypes: bool) -> Checksum {
+    let checksum = Checksum::new();
+    rayon::scope(|scope| {
+        if let Err(error) = (|| -> Result<()> {
+            for child in Path::new(".").read_dir()? {
+                let child = child?;
+                scope.spawn({
+                    let checksum = &checksum;
+                    move |scope| {
+                        entry(
+                            scope,
+                            label,
+                            checksum,
+                            Path::new(&child.file_name()),
+                            ignore_unknown_filetypes,
+                        );
+                    }
+                });
+            }
+            Ok(())
+        })() {
+            die(label, error);
+        }
+    });
+    checksum
+}
+
+fn entry<'scope>(
+    scope: &Scope<'scope>,
+    base: &'scope Path,
+    checksum: &'scope Checksum,
+    path: &Path,
+    ignore_unknown_filetypes: bool,
+) {
+    let metadata = match path.symlink_metadata() {
+        Ok(metadata) => metadata,
+        Err(error) => die(base.join(path), error),
+    };
+
+    let file_type = metadata.file_type();
+    let result = if file_type.is_file() {
+        file(checksum, path, metadata)
+    } else if file_type.is_symlink() {
+        symlink(checksum, path, metadata)
+    } else if file_type.is_dir() {
+        dir(
+            scope,
+            base,
+            checksum,
+            path,
+            ignore_unknown_filetypes,
+            metadata,
+        )
+    } else if file_type.is_socket() {
+        socket(checksum, path, metadata)
+    } else if ignore_unknown_filetypes {
+        Ok(())
+    } else {
+        die(base.join(path), "Unsupported file type");
+    };
+
+    if let Err(error) = result {
+        die(base.join(path), error);
+    }
+}
+
+fn file(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
+    let mut sha = begin(path, &metadata, b'f');
+
+    // Enforced by memmap: "memory map must have a non-zero length"
+    if metadata.len() > 0 {
+        let file = File::open(path)?;
+        let mmap = unsafe { Mmap::map(&file)? };
+        sha.update(&mmap);
+    }
+
+    checksum.put(sha);
+
+    Ok(())
+}
+
+fn symlink(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
+    let mut sha = begin(path, &metadata, b'l');
+    sha.update(path.read_link()?.as_os_str().as_bytes());
+    checksum.put(sha);
+
+    Ok(())
+}
+
+fn dir<'scope>(
+    scope: &Scope<'scope>,
+    base: &'scope Path,
+    checksum: &'scope Checksum,
+    path: &Path,
+    ignore_unknown_filetypes: bool,
+    metadata: Metadata,
+) -> Result<()> {
+    let sha = begin(path, &metadata, b'd');
+    checksum.put(sha);
+
+    for child in path.read_dir()? {
+        let child = child?.path();
+        scope.spawn(move |scope| entry(scope, base, checksum, &child, ignore_unknown_filetypes));
+    }
+
+    Ok(())
+}
+
+fn socket(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
+    let sha = begin(path, &metadata, b's');
+    checksum.put(sha);
+
+    Ok(())
+}
+
+fn begin(path: &Path, metadata: &Metadata, kind: u8) -> Sha1 {
+    let mut sha = Sha1::new();
+    let path_bytes = path.as_os_str().as_bytes();
+    sha.update([kind]);
+    sha.update((path_bytes.len() as u32).to_le_bytes());
+    sha.update(path_bytes);
+    sha.update(metadata.mode().to_le_bytes());
+    sha
+}
+
+#[test]
+fn test_cli() {
+    <Opt as clap::CommandFactory>::command().debug_assert();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,41 +15,12 @@
 )]
 
 use clap::Parser;
-use memmap::Mmap;
-use parking_lot::Mutex;
-use rayon::{Scope, ThreadPoolBuilder};
-use sha1::{Digest, Sha1};
 use std::cmp;
 use std::env;
-use std::error::Error;
-use std::fmt::{self, Display};
-use std::fs::{self, File, Metadata};
 use std::io::{self, Write};
-use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
-use std::process;
-use std::sync::Once;
 
-type Result<T> = std::result::Result<T, Box<dyn Error>>;
-
-fn die<P: AsRef<Path>, E: Display>(path: P, error: E) -> ! {
-    static DIE: Once = Once::new();
-
-    DIE.call_once(|| {
-        let path = path.as_ref().display();
-        let _ = writeln!(
-            io::stderr(),
-            "{}: {}: {}",
-            env!("CARGO_BIN_NAME"),
-            path,
-            error,
-        );
-        process::exit(1);
-    });
-
-    unreachable!()
-}
+use sha1dir::{canonicalize, checksum_current_dir, configure_thread_pool, die};
 
 #[derive(Debug, Parser)]
 #[command(about = "Compute checksum of directory.", version, author)]
@@ -70,7 +41,14 @@ struct Opt {
 fn main() {
     let opt = Opt::parse();
 
-    configure_thread_pool(&opt);
+    let threads = if let Some(jobs) = opt.jobs {
+        jobs
+    } else {
+        // Limit to 8 threads by default to avoid thrashing disk.
+        cmp::min(num_cpus::get(), 8)
+    };
+
+    configure_thread_pool(threads);
 
     if opt.dirs.is_empty() {
         let path = Path::new(".");
@@ -88,184 +66,4 @@ fn main() {
         let checksum = checksum_current_dir(&label, opt.ignore_unknown_filetypes);
         let _ = writeln!(io::stdout(), "{}  {}", checksum, label.display());
     }
-}
-
-fn configure_thread_pool(opt: &Opt) {
-    let threads = if let Some(jobs) = opt.jobs {
-        jobs
-    } else {
-        // Limit to 8 threads by default to avoid thrashing disk.
-        cmp::min(num_cpus::get(), 8)
-    };
-
-    let result = ThreadPoolBuilder::new().num_threads(threads).build_global();
-
-    // This is the only time the thread pool is initialized.
-    result.unwrap();
-}
-
-fn canonicalize<P: AsRef<Path>>(path: P) -> PathBuf {
-    match fs::canonicalize(&path) {
-        Ok(canonical) => canonical,
-        Err(error) => die(path, error),
-    }
-}
-
-struct Checksum {
-    bytes: Mutex<[u8; 20]>,
-}
-
-impl Checksum {
-    fn new() -> Self {
-        Checksum {
-            bytes: Mutex::new([0u8; 20]),
-        }
-    }
-}
-
-impl Display for Checksum {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for i in self.bytes.lock().as_ref() {
-            write!(f, "{:02x}", i)?;
-        }
-        Ok(())
-    }
-}
-
-impl Checksum {
-    fn put(&self, rhs: Sha1) {
-        for (lhs, rhs) in self.bytes.lock().iter_mut().zip(rhs.finalize()) {
-            *lhs ^= rhs;
-        }
-    }
-}
-
-fn checksum_current_dir(label: &Path, ignore_unknown_filetypes: bool) -> Checksum {
-    let checksum = Checksum::new();
-    rayon::scope(|scope| {
-        if let Err(error) = (|| -> Result<()> {
-            for child in Path::new(".").read_dir()? {
-                let child = child?;
-                scope.spawn({
-                    let checksum = &checksum;
-                    move |scope| {
-                        entry(
-                            scope,
-                            label,
-                            checksum,
-                            Path::new(&child.file_name()),
-                            ignore_unknown_filetypes,
-                        );
-                    }
-                });
-            }
-            Ok(())
-        })() {
-            die(label, error);
-        }
-    });
-    checksum
-}
-
-fn entry<'scope>(
-    scope: &Scope<'scope>,
-    base: &'scope Path,
-    checksum: &'scope Checksum,
-    path: &Path,
-    ignore_unknown_filetypes: bool,
-) {
-    let metadata = match path.symlink_metadata() {
-        Ok(metadata) => metadata,
-        Err(error) => die(base.join(path), error),
-    };
-
-    let file_type = metadata.file_type();
-    let result = if file_type.is_file() {
-        file(checksum, path, metadata)
-    } else if file_type.is_symlink() {
-        symlink(checksum, path, metadata)
-    } else if file_type.is_dir() {
-        dir(
-            scope,
-            base,
-            checksum,
-            path,
-            ignore_unknown_filetypes,
-            metadata,
-        )
-    } else if file_type.is_socket() {
-        socket(checksum, path, metadata)
-    } else if ignore_unknown_filetypes {
-        Ok(())
-    } else {
-        die(base.join(path), "Unsupported file type");
-    };
-
-    if let Err(error) = result {
-        die(base.join(path), error);
-    }
-}
-
-fn file(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
-    let mut sha = begin(path, &metadata, b'f');
-
-    // Enforced by memmap: "memory map must have a non-zero length"
-    if metadata.len() > 0 {
-        let file = File::open(path)?;
-        let mmap = unsafe { Mmap::map(&file)? };
-        sha.update(&mmap);
-    }
-
-    checksum.put(sha);
-
-    Ok(())
-}
-
-fn symlink(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
-    let mut sha = begin(path, &metadata, b'l');
-    sha.update(path.read_link()?.as_os_str().as_bytes());
-    checksum.put(sha);
-
-    Ok(())
-}
-
-fn dir<'scope>(
-    scope: &Scope<'scope>,
-    base: &'scope Path,
-    checksum: &'scope Checksum,
-    path: &Path,
-    ignore_unknown_filetypes: bool,
-    metadata: Metadata,
-) -> Result<()> {
-    let sha = begin(path, &metadata, b'd');
-    checksum.put(sha);
-
-    for child in path.read_dir()? {
-        let child = child?.path();
-        scope.spawn(move |scope| entry(scope, base, checksum, &child, ignore_unknown_filetypes));
-    }
-
-    Ok(())
-}
-
-fn socket(checksum: &Checksum, path: &Path, metadata: Metadata) -> Result<()> {
-    let sha = begin(path, &metadata, b's');
-    checksum.put(sha);
-
-    Ok(())
-}
-
-fn begin(path: &Path, metadata: &Metadata, kind: u8) -> Sha1 {
-    let mut sha = Sha1::new();
-    let path_bytes = path.as_os_str().as_bytes();
-    sha.update([kind]);
-    sha.update((path_bytes.len() as u32).to_le_bytes());
-    sha.update(path_bytes);
-    sha.update(metadata.mode().to_le_bytes());
-    sha
-}
-
-#[test]
-fn test_cli() {
-    <Opt as clap::CommandFactory>::command().debug_assert();
 }


### PR DESCRIPTION
I wanted to use functions from sha1dir inside a project of mine, but only an executable was available. Hence I moved most of the functions into the `lib.rs` and then imported the functions back into the `main.rs` and used them their. 

